### PR TITLE
fix faker function variable parsing

### DIFF
--- a/api/handler.js
+++ b/api/handler.js
@@ -54,7 +54,7 @@ function fake(str, user) {
 
     if (functionName.indexOf('faker') === 0) {
       try {
-        return functionName.split('.').reduce((o, i) => o[i], { faker })()
+        return split.reduce((o, i) => o[i], { faker })()
       } catch (error) {
         return '[Error: faker function not found]'
       }


### PR DESCRIPTION
Allow for properly parsing faker functions as inputs (as specified in website documentation)